### PR TITLE
Formats the GitHub App Key appropriately

### DIFF
--- a/PermissionsScraper/PermissionsScraper/Common/ApplicationConfig.cs
+++ b/PermissionsScraper/PermissionsScraper/Common/ApplicationConfig.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using Microsoft.Extensions.Configuration;
+using PermissionsScraper.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -15,6 +16,7 @@ namespace PermissionsScraper.Common
     /// </summary>
     public class ApplicationConfig
     {
+        private string _gitHubAppKey;
         private Dictionary<string, string> _regexReplacements;
 
         public string Instance { get; set; } = "https://login.microsoftonline.com/{0}";
@@ -25,7 +27,14 @@ namespace PermissionsScraper.Common
 
         public string ClientId { get; set; }
 
-        public string GitHubAppKey { get; set; }
+        public string GitHubAppKey
+        {
+            get => _gitHubAppKey;
+            set
+            {
+                _gitHubAppKey = value.FormatPrivateKey();
+            }
+        }
 
         public string Authority
         {

--- a/PermissionsScraper/PermissionsScraper/Helpers/PermissionsFormatHelper.cs
+++ b/PermissionsScraper/PermissionsScraper/Helpers/PermissionsFormatHelper.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using System;
 using System.Text.RegularExpressions;
 using PermissionsScraper.Common;
 
@@ -17,6 +18,11 @@ namespace PermissionsScraper.Helpers
         /// <returns>The Service Principal JSON response data with the regex transformations applied.</returns>
         internal static string FormatServicePrincipalResponse(string spJsonResponse, ApplicationConfig config)
         {
+            if (string.IsNullOrEmpty(spJsonResponse))
+            {
+                throw new ArgumentNullException(nameof(spJsonResponse), "Parameter cannot be null or empty");
+            }
+
             string cleanedSpJson = spJsonResponse;
 
             foreach (var item in config.RegexPatterns)
@@ -27,6 +33,24 @@ namespace PermissionsScraper.Helpers
             }
 
             return cleanedSpJson;
+        }
+
+        /// <summary>
+        /// Formats the private key to add newline characters appropriately.
+        /// </summary>
+        /// <param name="key">The private key.</param>
+        /// <returns>The private key with newline characters appropriately added.</returns>
+        internal static string FormatPrivateKey(this string key)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentNullException(nameof(key), "Parameter cannot be null or empty");
+            }
+
+            var sections = key.Split("-----BEGIN RSA PRIVATE KEY-----", StringSplitOptions.RemoveEmptyEntries);
+            sections = sections[0].Split("-----END RSA PRIVATE KEY-----", StringSplitOptions.RemoveEmptyEntries);
+
+            return "-----BEGIN RSA PRIVATE KEY-----\r\n" + sections[0] + "\r\n-----END RSA PRIVATE KEY-----";
         }
     }
 }


### PR DESCRIPTION
Proposes:
- Formatting the GitHub app key by adding newline characters after the text `-----BEGIN RSA PRIVATE KEY-----` and before the text `-----END RSA PRIVATE KEY-----`. This is to help read the config esp. from Azure app config.