### PR TITLE
Update Azure subscription id in pipeline

### DIFF
--- a/.azure-pipelines/deploy-permissions-scraper.yml
+++ b/.azure-pipelines/deploy-permissions-scraper.yml
@@ -17,9 +17,6 @@ trigger:
 pr: none
 
 variables:
-  # Azure Resource Manager connection created during pipeline creation
-  azureSubscription: '68397ef5-9754-46e7-9572-9b15d12367f1'
-
   # Function app name
   functionAppName: 'permissionscraper'
 
@@ -82,7 +79,7 @@ stages:
           - task: AzureFunctionApp@1
             displayName: 'Azure functions app deploy'
             inputs:
-              azureSubscription: '$(azureSubscription)'
+              azureSubscription: $(azureSubscription)
               appType: functionApp
               appName: $(functionAppName)
               package: '$(Pipeline.Workspace)/drop/$(Build.BuildId).zip'

--- a/.azure-pipelines/deploy-permissions-scraper.yml
+++ b/.azure-pipelines/deploy-permissions-scraper.yml
@@ -18,7 +18,7 @@ pr: none
 
 variables:
   # Azure Resource Manager connection created during pipeline creation
-  azureSubscription: '984f7c25-03a1-456c-a4c0-4b97f9d61962'
+  azureSubscription: '68397ef5-9754-46e7-9572-9b15d12367f1'
 
   # Function app name
   functionAppName: 'permissionscraper'


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-permissions-scraper/issues/21

This PR:

- Replaces the the `azureSubscription` property value with the **Microsoft Graph SDK PPE** subscription id.